### PR TITLE
Fix #21 by not converting strains in descriptions and paragraphs

### DIFF
--- a/src/bml/html.py
+++ b/src/bml/html.py
@@ -14,11 +14,10 @@ EXTENSION = '.htm'
 
 def html_replace_suits(matchobj):
     text = matchobj.group(0)
-    # We have to use numeric character references to avoid choking the XML parser
-    text = text.replace('C', '<span class="ccolor">&#x2663;</span>')
-    text = text.replace('D', '<span class="dcolor">&#x2666;</span>')
-    text = text.replace('H', '<span class="hcolor">&#x2665;</span>')
-    text = text.replace('S', '<span class="scolor">&#x2660;</span>')
+    text = text.replace('C', '!c')
+    text = text.replace('D', '!d')
+    text = text.replace('H', '!h')
+    text = text.replace('S', '!s')
     text = text.replace('N', 'NT')
     return text
 
@@ -31,14 +30,15 @@ def html_bidtable(et_element, children, root=False):
         for i in range(len(children)):
             c = children[i]
             li = ET.SubElement(ul, 'li')
-
-            if bml.args.tree:
-                if root:
-                    li.attrib['class'] = 'root'
-                elif i == len(children) - 1:
-                    li.attrib['class'] = 'last node'
-                else:
-                    li.attrib['class'] = 'node'
+            if not bml.args.tree:
+                div = ET.SubElement(li, 'div')
+                div.attrib['class'] = 'start'
+            elif root:
+                li.attrib['class'] = 'root'
+            elif i == len(children) - 1:
+                li.attrib['class'] = 'last node'
+            else:
+                li.attrib['class'] = 'node'
 
             root = False
 
@@ -50,9 +50,7 @@ def html_bidtable(et_element, children, root=False):
             bml.logger.debug("bid: %s; description line 1: %s" % (bid, desc_rows[0]))
 
             if not bml.args.tree:
-                div = ET.XML(f'<div>{ bid }</div>')
-                li.append(div)
-                div.attrib['class'] = 'start'
+                div.text = bid
                 div.tail = desc_rows[0]
                 desc_rows = desc_rows[1:]
                 for r, dr in enumerate(desc_rows):
@@ -65,7 +63,7 @@ def html_bidtable(et_element, children, root=False):
                     div.tail = NBSP if dr == '.' and r == len(desc_rows) - 1 else dr
             elif len(desc_rows) == 1 and (not desc_rows[0] or desc_rows[0].isspace()):
                 # empty description: just store the bid
-                li.append(ET.XML(f'<div>{ bid }</div>'))
+                li.text = bid
             else:
                 # use a table to store the bid (one column) and description lines (each line a row)
                 table = ET.SubElement(li, 'table')
@@ -73,8 +71,8 @@ def html_bidtable(et_element, children, root=False):
                     tr = ET.SubElement(table, 'tr')
                     # bid only first time
                     if r == 0:
-                        td = ET.XML(f'<td>{ bid }</td>')
-                        tr.append(td)
+                        td = ET.SubElement(tr, 'td')
+                        td.text = bid
                         td.attrib['rowspan'] = str(len(desc_rows))
                         td.attrib['class'] = 'node'
                     # description

--- a/src/bml/html.py
+++ b/src/bml/html.py
@@ -43,10 +43,10 @@ def html_bidtable(et_element, children, root=False):
             root = False
 
             desc_rows = c.desc.split('\\n')  # can be more than one line
-            bid = re.sub(r'^P$', 'Pass', c.bid)
-            bid = re.sub(r'^R$', 'Rdbl', bid)
-            bid = re.sub(r'^D$', 'Dbl', bid)
-            bid = re.sub(r'\d([CDHS]|N(?!T))+', html_replace_suits, bid)
+            bid = re.sub(r'\d([CDHS]|N(?!T))+', html_replace_suits, c.bid)
+            bid = re.sub('P', 'Pass', bid)
+            bid = re.sub('R', 'Rdbl', bid)
+            bid = re.sub('D', 'Dbl', bid)
             bml.logger.debug("bid: %s; description line 1: %s" % (bid, desc_rows[0]))
 
             if not bml.args.tree:

--- a/src/bml/html.py
+++ b/src/bml/html.py
@@ -102,6 +102,10 @@ def to_html(content):
     meta.attrib['http-equiv'] = "Content-Type"
     meta.attrib['content'] = "text/html; charset=utf-8"
 
+    viewport = ET.SubElement(head, 'meta')
+    viewport.attrib['name'] = 'viewport'
+    viewport.attrib['content'] = 'width=device-width, initial-scale=1'
+
     title = ET.SubElement(head, 'title')
     title.text = content.meta['TITLE'] if content.meta['TITLE'] else 'No title supplied'
 


### PR DESCRIPTION
In this MR, we stop converting `\d[SHDCN]` in descriptions and paragraphs.  This changes avoids unexpected suit symbols like "4♠FG" in the generated HTML files.  The new behavior is also consistent to the documentation and the LaTeX converter.